### PR TITLE
Fix syntax, and export Zika.

### DIFF
--- a/zika.js
+++ b/zika.js
@@ -1,3 +1,3 @@
 'use strict';
-const Zika => {};
+export const Zika = _=>_;
 Object.freeze(Zika.prototype);


### PR DESCRIPTION
In a true ES6 environment, line 2 would be self-sufficient because fat arrow functions don't have a prototype and aren't constructible. 

However, transpilers turn them into plain old functions, so line 3 is necessary if you're using Babel, Bublé or the Closure compiler.
